### PR TITLE
Added aws_service_access_principals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ for more details.
 
 ### Inputs
 
-| Name                  | Description                                                                             | Default | Required |
-|-----------------------|-----------------------------------------------------------------------------------------|:-------:|:--------:|
-| feature_set           | The feature set to enable for the organization (one of "ALL" or "CONSOLIDATED_BILLING") | ALL     | yes      |
-| organizational_units  | The tree of organizational units in the organization                                    | -       | yes      |
-| accounts              | The accounts that are part of the organization                                          | -       | yes      |
+| Name                          | Description                                                                             | Default | Required |
+|-------------------------------|-----------------------------------------------------------------------------------------|:-------:|:--------:|
+| feature_set                   | The feature set to enable for the organization (one of "ALL" or "CONSOLIDATED_BILLING") | ALL     | yes      |
+| aws_service_access_principals | List of AWS service principal names for which you want to enable integration with your organization. This is typically in the form of a URL, such as service-abbreviation.amazonaws.com. | ALL     | yes      |
+| organizational_units          | The tree of organizational units in the organization                                    | -       | yes      |
+| accounts                      | The accounts that are part of the organization                                          | -       | yes      |
 
 ### Outputs
 

--- a/organization.tf
+++ b/organization.tf
@@ -1,3 +1,4 @@
 resource "aws_organizations_organization" "organization" {
-  feature_set = var.feature_set
+  aws_service_access_principals = var.aws_service_access_principals
+  feature_set                   = var.feature_set
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,13 @@ variable "feature_set" {
   description = "The feature set of the organization. One of 'ALL' or 'CONSOLIDATED_BILLING'."
 }
 
+variable "aws_service_access_principals" {
+  type = list
+  default = []
+  description = "List of AWS service principal names for which you want to enable integration with your organization. This is typically in the form of a URL, such as sso.amazonaws.com."
+}
+
+
 variable "organizational_units" {
   type = list(object({
     name = string,


### PR DESCRIPTION
Required in order to manage SSO in Organization.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_organization#aws_service_access_principals